### PR TITLE
add start_app() to start app by packagename.

### DIFF
--- a/pyhermit/hermit.py
+++ b/pyhermit/hermit.py
@@ -253,3 +253,9 @@ class Hermit(object):
 
     def data_device(self):
         return self.request('/data/device').json()
+    
+    def start_app(self, pkg: str):
+        result = self.request('/shell/start?packageName=' + pkg).json()
+        if result['code']:
+            return False
+        return True


### PR DESCRIPTION
great job, hermit-py with hermit made android automation much easyer.  
thank you soooooo much.  
I'm afraid you have forgot the 'start_app' func which start app through packageName, because in the api document i have found the api '/shell/start'. so i'm trying to fix it, add the func to start app.  
wish you merge it or add the func in your own way.  
Thanks again!  